### PR TITLE
fix: provide onSearchParameters

### DIFF
--- a/app/pages/index.js
+++ b/app/pages/index.js
@@ -69,11 +69,13 @@ function Search({
   resultsState,
   indexName,
   onSearchStateChange,
+  ...props
 }) {
   console.log(searchState);
 
   return (
     <InstantSearch
+      {...props}
       searchClient={searchClient}
       indexName={indexName}
       searchState={searchState}


### PR DESCRIPTION
`findResultsState` forwards the props given to the function but it also provides an additional one called [`onSearchParameters`](https://www.algolia.com/doc/api-reference/widgets/instantsearch/react/#widget-param-onsearchparameters) ([source](https://github.com/algolia/react-instantsearch/blob/b5fe4f76b15523835a3ca10f8d82ba24f937a545/packages/react-instantsearch-dom/src/core/createInstantSearchServer.js#L126-L131)). Without this function InstantSearch is not aware of the widgets mounted in the three. The SSR "works" but trigger the most basic request possible. That's why we have the flash: first paint is done with the basic request made on the server until the client kicks in. 

![Untitled](https://user-images.githubusercontent.com/6513513/72430397-838c8a00-3792-11ea-8b12-63d0df8916ad.gif)
